### PR TITLE
chore(workflow): add Claude Code team workflow drafts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+<!--
+Atlas notebooks pull-request template.
+Pete reviews visually via the preview URL; Brayden reviews the code.
+Keep the visual sections short and the technical sections detailed.
+-->
+
+## Summary
+
+<!-- One sentence: what does this PR change user-side? Not for developers. -->
+
+## Issues closed
+
+<!-- e.g. CR-004, CR-005, CR-007. Or "none — small follow-up". -->
+
+Closes:
+
+## Preview URL
+
+<!-- Cloudflare Pages auto-builds on every push. Paste the preview URL here.
+     Project lead's review starts on this URL. -->
+
+https://<branch-slug>.adaptation-atlas-nb.pages.dev/
+
+## What to look at on the preview
+
+<!-- Three or four specific things the reviewer should click / scroll to.
+     Don't say "review the whole notebook" — be specific. -->
+
+-
+-
+-
+
+---
+
+## Project lead review (Pete)
+
+<!-- Tick when done. -->
+
+- [ ] Preview URL loads cleanly (no obvious errors, no blank sections)
+- [ ] Each "look at" item above behaves as described
+- [ ] Copy reads correctly to a non-technical audience
+- [ ] No regression in unrelated sections
+- [ ] Approved for technical review
+
+## Technical review (Brayden)
+
+<!-- Tick when done. -->
+
+- [ ] Branch off the correct notebook branch (`notebooks/<name>`)
+- [ ] Conventional commit messages with notebook scope
+- [ ] No deletions of code that weren't explicitly requested
+- [ ] French translations have a francophone reviewer signoff (if applicable)
+- [ ] PR targets the notebook branch, not `develop` or `main`
+- [ ] Lint / build passes on Cloudflare Pages
+- [ ] No new dependencies added without sign-off
+
+---
+
+## Out of scope / deferred
+
+<!-- Anything you noticed while making this change but did NOT touch.
+     This is how Pete tracks what to put in the next ISSUES.md round. -->
+
+-
+
+## Notes for the dev
+
+<!-- Technical detail Brayden needs: structural decisions, things to watch
+     when re-running locally, performance notes, etc. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,226 @@
+# Claude Code — project guide for `atlas_notebooks`
+
+**Read this in full before making any change.** This file is auto-loaded by
+Claude Code on every invocation in this repository. It encodes the team's
+hard rules and conventions so Claude Code stays inside the lines without
+the operator needing to re-paste them in every prompt.
+
+---
+
+## Repository at a glance
+
+**Project:** Africa Agriculture Adaptation Atlas — interactive notebooks for
+climate adaptation analysis at subnational level.
+**Stack:** Quarto + Observable JavaScript, rendered to static HTML, deployed
+on Cloudflare Pages. Heavy data lives in Parquet on S3, queried in-browser
+via DuckDB-WASM.
+**Audience:** climate-rationale authors (GCF proposal writers, adaptation
+planners), researchers, decision-makers.
+
+## Branch model — critical
+
+This repo uses **one long-lived branch per notebook**, not a single trunk.
+
+- `main` — production. **Never** push or open PRs against `main` directly.
+- `develop` — staging. PRs land here first; promotion to `main` is on a
+  release cadence the dev (Brayden) owns.
+- `notebooks/<name>` — long-lived branch for each notebook. Active examples:
+  `notebooks/climateRationale`, `notebooks/roi_tool`, `notebooks/lossDamage`,
+  `notebooks/gender`, `notebooks/cis-notebook`, `notebooks/hazard-exposure`,
+  `notebooks/vulnerability-notebook`, `notebooks/solutions`.
+
+For any code change:
+
+1. Branch **off the relevant notebook branch** (not off `develop`, not off
+   `main`).
+2. Use the naming convention:
+   - `fix/<short-notebook>-<slug>` for bug fixes
+   - `feat/<short-notebook>-<slug>` for new features
+   - `chore/<short-notebook>-<slug>` for housekeeping
+   - `docs/<short-notebook>-<slug>` for documentation
+3. **Open the PR against the notebook branch**, not against `develop`. The
+   dev will fast-forward / rebase the notebook branch into `develop`
+   themselves when ready.
+4. Cloudflare Pages auto-builds a preview URL on every push:
+   `https://<branch-slug>.adaptation-atlas-nb.pages.dev/`. Paste this URL
+   into the PR description so the project lead can review visually.
+
+## Hard rules
+
+1. **Never delete code without explicit project-lead permission.** If a block
+   looks dead, commented-out, or obsolete, **flag it in the PR description**
+   and let the human decide. This rule is non-negotiable and overrides any
+   instinct to clean up.
+2. **Never auto-merge.** All PRs require human approval — project lead for
+   the visual review, dev for the technical review. Open PRs as **draft**
+   until they're ready.
+3. **One PR per scope group.** If working from an `ISSUES.md` backlog,
+   implement one PR group per PR. Do not mix groups unless explicitly
+   instructed.
+4. **Stop and ask when ambiguous.** If a `before-string` in `ISSUES.md`
+   does not match the file exactly, **do not improvise**. Stop, report
+   the mismatch, and wait for human input.
+5. **French translations need human review.** Never merge a `feat/*-i18n-*`
+   PR without an approved francophone reviewer comment on the PR. Mark
+   these PRs `draft` until that approval lands.
+6. **Do not modify these files without an explicit `chore/*-workflow` PR:**
+   `CLAUDE.md` (this file), `.github/PULL_REQUEST_TEMPLATE.md`, anything
+   under `playbook/`.
+
+## Conventional commits
+
+Use Conventional Commits with a notebook-scoped subject:
+
+- `fix(climateRationale): correct futurePeriods to match parquet partitions`
+- `feat(roi_tool): add download button for projected returns table`
+- `chore(workflow): update CLAUDE.md branch naming convention`
+- `docs(climateRationale): expand Methods section`
+
+Squash-merge by default; commit messages are the public-facing audit trail.
+
+## Modular shared code — the architectural rule
+
+**The notebooks are not self-contained.** This repository is deliberately
+designed so that each notebook pulls from a shared library of helpers,
+components, data, and translations. The design principle is reusable,
+modular content — one place for each piece of behaviour, used by many
+notebooks.
+
+**Before adding a function or string inside a notebook, check whether it
+already exists in shared code.** Hand-rolling a duplicate is a regression
+of this design. Likewise: when fixing a bug, ask whether the right fix
+is in the notebook or in the shared module the notebook is calling.
+
+**Changes to shared code affect every notebook that imports it.** That
+makes them higher-stakes than changes inside one `notebooks/<name>/`
+folder. Specifically:
+
+- Before merging any change under `helpers/`, `components/`, or
+  `data/shared/`, **list every notebook that imports the touched file**
+  (`grep -lr "<filename>" notebooks/ components/`), and call this out in
+  the PR description so the project lead can visually check each affected
+  notebook on the preview deploy before approving.
+- Never delete or rename an exported symbol in shared code without
+  explicit project-lead approval — the breakage radius is the whole
+  repo.
+
+## Repository layout
+
+Within each notebook branch:
+
+```
+notebooks/<name>/notebook.qmd        ← per-notebook   the Quarto + OJS source
+data/<name>/nbText.json              ← per-notebook   translatable copy (en/fr)
+data/<name>/nbData.json              ← per-notebook   dataset catalogue
+                                                       (drives the Data Sources
+                                                       cards in Methods)
+
+data/shared/                         ← SHARED         cross-notebook data
+  generalTranslations.json             SHARED         · section/hazard/scenario labels
+  atlas_countries.json                 SHARED         · ISO3 + translated names
+  MapSpamCrops.json                    SHARED         · crop categorisation + labels
+  atlas_gaul24_a0_*.topojson           SHARED         · admin-0/1/2 boundaries
+  nbData.schema.json                   SHARED         · schema for per-notebook nbData
+
+components/                          ← SHARED         OJS components imported by
+                                                       most notebooks
+  atlasTable.ojs                       SHARED         · filterable data table
+  dataDescriptor.js                    SHARED         · Data Sources cards renderer
+  _adminSelectorsMulti.qmd             SHARED         · admin selectors (multi)
+  _adminSelectors.{ojs,qmd}            SHARED         · admin selectors (single)
+  _lang.qmd                            SHARED         · language toggle + Lang module
+
+helpers/                             ← SHARED         cross-notebook utilities
+  uiComponents.ojs                     SHARED         · atlasHero, downloadButton,
+                                                       multiLineText, loaderDiv
+  std.ojs                              SHARED         · formatters, inputTemplate,
+                                                       generateDB, wrapTickLabel
+  lang.js                              SHARED         · Lang module (i18n engine)
+  data.js                              SHARED         · patchWindowsCache,
+                                                       cleanAdminInput_SQL
+  enhancedMultiSelect.ojs              SHARED         · multi-select widget
+  multiSelect.ojs                      SHARED         · simpler multi-select
+  toc.ojs                              SHARED         · table-of-contents builder
+  boundaries.js                        SHARED         · boundary path constants
+
+_quarto.yml                          ← SHARED         site configuration (navbar,
+                                                       theming, post-render scripts)
+images/                              ← SHARED         logos, icons, hero crops
+styles.css                           ← SHARED         site-wide styles
+```
+
+**Rule of thumb for a change:** if you're editing only files under
+`notebooks/<name>/` or `data/<name>/`, the change is **local** —
+scoped to one notebook, lower-stakes. If you're touching anything else,
+the change is **shared** — higher-stakes, requires the wider checks
+above.
+
+## Standard patterns
+
+- **Translation pipeline.** All user-facing copy goes through `_lang(...)`
+  from `components/_lang.qmd`. Strings live in `nbText.json` (per-notebook)
+  or `data/shared/generalTranslations.json` (cross-notebook). Never
+  hardcode user-facing strings in OJS code.
+- **Dataset catalogue.** Datasets are declared in `data/<name>/nbData.json`
+  and rendered into the Methods appendix by
+  `components/dataDescriptor.js`. New datasets need a real `description`
+  (not empty) and the S3 path.
+- **Figure captions.** Use the `multiLineText([...], "atlasFigCaption")`
+  helper from `helpers/uiComponents.ojs`. Don't invent new caption
+  styles.
+- **Plots.** Respect the existing `width` variable. Add `marginRight: 120`
+  (or similar) when faceting on a long-label axis.
+- **Loaders.** Use `loaderDiv("<id>")` from `helpers/uiComponents.ojs`
+  to reserve a spot for a plot; render into it with `renderToDiv`.
+- **Admin selectors.** Use `_adminSelectorsMulti.qmd` (multi-region) or
+  `_adminSelectors.qmd` (single). Don't roll your own.
+- **Database.** Heavy data goes through DuckDB-WASM via `generateDB`
+  in `helpers/std.ojs`. Per-notebook `nbData.json` lists the parquet
+  partitions to mount.
+
+## When to involve the human
+
+You don't have to ask permission for routine edits — applying a typo fix
+from an `ISSUES.md`, reformatting JSON, adding a missing translation
+key with a placeholder. Do ask before:
+
+- **Editing anything under `helpers/`, `components/`, or `data/shared/`** —
+  the change affects every notebook that imports it. List the affected
+  notebooks in your reply when asking.
+- Changing architecture (e.g. extracting a component, restructuring
+  selectors across sections)
+- Removing or renaming an exported function or component
+- Adding a new dependency
+- Touching CI / build / deploy configuration
+- Modifying `_quarto.yml`, the navbar, or anything in the site chrome
+- Anything outside the notebook branch you were dispatched to
+
+When in doubt: **stop and ask the project lead.**
+
+## Operator (dispatcher) contract
+
+The operator dispatching you is the **project lead** (currently Pete Stewart,
+<p.steward@cgiar.org>), not the developer (Brayden Youngberg). The project
+lead is **not a developer** and will not read code-level diffs in detail —
+they review preview URLs and the PR description.
+
+Therefore:
+
+- Write PR descriptions for a **non-developer audience**. Lead with what
+  changed user-side, screenshots-or-equivalent of the preview, and which
+  `CR-NNN` issues this closes. Put technical detail at the bottom for the dev.
+- Surface anything surprising you encountered (e.g. "while making the
+  change, I noticed X also seems broken — should I open a follow-up issue?").
+- If you completed only part of an `ISSUES.md` group, **say so explicitly**.
+  Don't silently defer.
+
+## Out-of-scope topics in this repo
+
+These exist but live elsewhere — do not work on them via this repo without
+checking first:
+
+- The CGIAR Climate Data Hub (CDH) — separate platform, will eventually host
+  the S3 data this repo reads.
+- The GCF-aligned notebook (separate from `climateRationale`) — under
+  scoping; data requirements memo from Cesare Scartozzi.
+- The Atlas main website — different repo, separate deploy.

--- a/playbook/WORKFLOW.md
+++ b/playbook/WORKFLOW.md
@@ -1,0 +1,187 @@
+# Notebook editing workflow — four tiers, three roles
+
+A team workflow for evolving the Atlas notebooks. Built around the
+assumption that the **project lead is not a developer** but needs to be
+able to dispatch substantial changes, evaluate the results, and only
+involve the dev for technical review and merge.
+
+---
+
+## Roles
+
+| Role | Person (today) | Responsibility |
+|---|---|---|
+| **Project lead** | Pete Stewart (CIAT) | Owns priorities. Triages feedback. Dispatches Claude Code. Reviews preview URLs. Signs off on user-facing behaviour. |
+| **Developer** | Brayden Youngberg (CIAT) | Owns the codebase architecture. Technical review on PRs. Merges to `develop` and `main`. Final arbiter on technical decisions Claude Code can't make. |
+| **Claude Code** | CLI tool on the project lead's machine | Implements edits in feature branches. Opens draft PRs. Does not merge. Does not push to `main`. Asks when ambiguous. |
+| **Chat-mode Claude** | Web / desktop session (not in this repo) | Helps the project lead specify issues, draft handover folders, and evaluate output. Does not run code. |
+| **Contributor / user** | Anyone | Surfaces feedback. Tests previews. |
+
+---
+
+## Tiers
+
+### Tier 1 — Capture
+
+**Who:** anyone — project lead, users, field teams, dev, partners.
+**What:** raw feedback. Could be Slack messages, walkthroughs, meeting
+recordings, PDFs, screenshots, training-session notes, Github issues.
+**Where it lands:** an agreed intake channel (see "Open questions" at
+the bottom — needs a team decision).
+**Effort:** zero structure required. Just capture.
+
+### Tier 2 — Specify (project lead + chat-mode Claude)
+
+**Who:** project lead, in a chat-mode Claude session (web / desktop /
+Cowork).
+**Output:** a **per-project handover folder** in OneDrive. Until proper
+templates are extracted, the `Claude Climate Rational Project/` handover
+folder in OneDrive serves as the worked example. Contains:
+- `ISSUES.md` — structured backlog with `before-string` fields ready
+  for mechanical search-and-replace
+- `DECISIONS.md` — running audit trail of project-lead decisions on
+  open questions
+- `README.md` — orientation for whoever picks up the work
+- `context/` — supporting documents (planning, walkthrough notes,
+  worked examples)
+- `reference/` — source materials referenced in `ISSUES.md` (e.g. the
+  Togo SAT report for the CR notebook)
+
+**How:** see the existing
+`Claude Climate Rational Project/` folder for a worked example. The
+project lead converges on the handover package by feeding raw signal
+to Claude in chat, asking clarifying questions one at a time, and
+updating `DECISIONS.md` as they go.
+
+### Tier 3 — Implement (project lead dispatches Claude Code via GitHub)
+
+**Who:** project lead, in a browser. **No local terminal, no install.**
+**Where Claude Code runs:** in GitHub's cloud, via the
+`anthropics/claude-code-action` workflow installed in
+`.github/workflows/claude.yml`.
+**Input:** the handover folder from Tier 2 (paths referenced by the issue).
+**Output:** one draft pull request per PR group in `ISSUES.md`.
+
+**Standard sequence:**
+
+1. On `github.com/AdaptationAtlas/atlas_notebooks`, open a new issue
+   using the **"Dispatch Claude Code"** issue template
+   (`.github/ISSUE_TEMPLATE/dispatch-claude.md`). Fill in the notebook
+   branch, the handover folder path, and the PR letter. Submit.
+2. The action fires automatically because the issue body contains
+   `@claude`. Claude Code starts in a GitHub-hosted runner.
+3. Claude Code:
+   - Reads `CLAUDE.md` at the repo root.
+   - Follows the link to the handover folder (mounted via the runner's
+     filesystem if it's in the repo, or via direct file paths if the
+     team mirrors the handover into the repo's `playbook/handovers/`
+     subfolder — see "Open questions" below).
+   - Cuts a feature branch off the notebook branch.
+   - Applies the changes for the requested PR group, one issue at a
+     time, using `before-string` matches.
+   - Stops and asks (via a PR comment) if anything is ambiguous.
+   - Commits with a conventional-commit message.
+   - Opens a **draft** pull request against the notebook branch.
+   - Pastes the preview URL into the PR description.
+4. Cloudflare Pages auto-builds the preview on the new branch.
+
+**Iterating on a draft PR:** comment on the PR with `@claude please also
+change X`. The action picks up the comment, makes the further change on
+the same branch, and the preview rebuilds. No need to dispatch a new
+issue per iteration.
+
+**Local CLI as a fallback:** if you (or a colleague) prefer running
+Claude Code locally — e.g. for sensitive work that shouldn't touch
+GitHub's cloud, or for fast iteration without round-tripping through
+the GitHub UI — you can. The same `CLAUDE.md` + `ISSUES.md` mechanism
+applies; you'd push the branch yourself. This is the secondary path,
+not the primary.
+
+### Tier 3.5 — Visual review (project lead)
+
+**Who:** project lead, on a browser.
+**Input:** the preview URL from the draft PR.
+**Tool:** `playbook/checklists/PETE_PREVIEW_REVIEW.md`.
+
+The project lead opens the preview, ticks through the checklist, and
+either approves the PR (moves it from draft to ready-for-review) or
+comments on it asking for changes. Claude Code can re-engage on the
+same branch to apply those changes.
+
+### Tier 4 — Integrate (developer)
+
+**Who:** developer (Brayden).
+**Input:** a ready-for-review PR with project-lead sign-off in the
+description.
+**Tool:** `playbook/checklists/BRAYDEN_TECH_REVIEW.md` (suggestion;
+developer owns this).
+
+Developer reviews the code, requests changes if needed, and merges
+to the notebook branch. Promotion of the notebook branch into
+`develop` and then `main` follows the existing release cadence.
+
+---
+
+## A worked example — the Climate Rationale notebook, 2026-05
+
+This is the workflow in motion right now:
+
+1. **Tier 1 (capture):** Walkthrough by Pete, walkthrough notes from
+   Majambo, the Togo SAT report as a visual reference, Cesare's
+   GCF data-requirements memo, screenshots from the live notebook.
+2. **Tier 2 (specify):** A chat-mode Claude session reviewed the
+   notebook source, the live page, and all the captured material.
+   Produced `Claude Climate Rational Project/ISSUES.md` (45 issues
+   across 11 PRs) and `DECISIONS.md` (seven decisions logged with
+   reasoning). Pete reviewed and signed off.
+3. **Tier 3 (implement):** *About to start.* Pete will dispatch
+   Claude Code to the highest-priority unblocked PRs (PR-H typos
+   first, then PR-D downloads, etc.).
+4. **Tier 3.5 (visual review):** Pete will check each preview URL.
+5. **Tier 4 (integrate):** Brayden will merge to
+   `notebooks/climateRationale`, then to `develop` on his cadence.
+
+---
+
+## Why this shape
+
+- **Separation of concerns.** Specification (chat-mode Claude),
+  implementation (Claude Code), and integration (developer) are
+  three different jobs that benefit from different tools and
+  different review depths.
+- **No-developer bottleneck.** The project lead can move work
+  forward without the developer being in the room. The developer
+  arrives at the end with structured PRs they can review in batches.
+- **Preview URLs do the heavy lifting.** Because Cloudflare Pages
+  auto-builds every branch, the project lead can visually evaluate
+  a change without ever running anything locally.
+- **`ISSUES.md` is the contract.** Claude Code receives a precise,
+  search-and-replace-grade specification. It doesn't have to guess
+  what "fix the typo" means.
+- **`DECISIONS.md` is the audit trail.** Future contributors (and
+  future Claude sessions) can reconstruct why a thing was done a
+  particular way.
+- **Hard guardrails in `CLAUDE.md`.** Claude Code can't push to
+  main, can't delete code, can't auto-merge. The repo enforces
+  the workflow.
+
+---
+
+## Open questions the team still needs to answer
+
+1. **Tier 1 intake.** Where does raw feedback land — a `#atlas-feedback`
+   Slack channel, a shared OneDrive folder, GitHub issues, or a mix?
+2. **Notification protocol.** When Claude Code opens a draft PR, how
+   does the project lead get notified? GitHub email, a Slack hook,
+   manual?
+3. **Tier 4 SLA.** What's the rough turnaround target on developer
+   technical review? Days, a sprint, a release window?
+4. **Multi-notebook concurrency.** When several notebooks are in
+   flight (CR + ROI + Gender), is the developer doing all reviews
+   serially, or are some delegated?
+5. **Brayden's review checklist.** The version in
+   `checklists/BRAYDEN_TECH_REVIEW.md` is a suggestion. Brayden to
+   own and edit it.
+
+These don't block adopting the workflow today — but should be
+agreed within the first few PR cycles.

--- a/playbook/checklists/BRAYDEN_TECH_REVIEW.md
+++ b/playbook/checklists/BRAYDEN_TECH_REVIEW.md
@@ -1,0 +1,20 @@
+# Developer technical review — placeholder
+
+This file is a **placeholder** for the developer (Brayden) to own and edit.
+
+Pete's suggestion as a starting point (not binding):
+
+- Branch named per `CLAUDE.md` convention (`fix|feat|chore|docs/<notebook>-<slug>`).
+- Targets the correct notebook branch (e.g. `notebooks/climateRationale`),
+  not `develop` or `main`.
+- Conventional commit messages with notebook scope.
+- No code deletions that weren't explicitly requested in `ISSUES.md`.
+- French translations have a francophone-reviewer signoff comment if the PR
+  is a `feat/*-i18n-*`.
+- Lint / Quarto build passes (Cloudflare Pages CI).
+- No new external dependencies without prior discussion.
+- Project lead has posted "Visual review OK" on the PR.
+- Cloudflare Pages preview URL is current and reflects the merged-in state.
+
+Brayden — please edit this file to match what you actually want enforced.
+The team will follow whatever's here.

--- a/playbook/checklists/PETE_PREVIEW_REVIEW.md
+++ b/playbook/checklists/PETE_PREVIEW_REVIEW.md
@@ -1,0 +1,86 @@
+# Project-lead preview review — checklist
+
+A short checklist for the project lead to tick through on every draft PR
+before passing it to the developer. Aim is: catch user-facing problems
+the dev can't reasonably know about. Not a code review.
+
+---
+
+## 1. Preview URL loads
+
+- [ ] Open the URL Claude Code pasted into the PR description.
+- [ ] Page renders. No blank sections, no broken layouts, no "loading…"
+      stuck forever.
+- [ ] Language toggle works (English / French).
+
+## 2. The issues Claude Code said it fixed are actually fixed
+
+- [ ] Open ISSUES.md alongside the preview. For each CR-NNN listed as
+      closed in the PR description: navigate to the affected place on the
+      page and check the `what-users-see` text from ISSUES.md is gone /
+      changed.
+
+## 3. Look at the area around the change
+
+- [ ] One section above and one section below the change site — anything
+      look different from before?
+- [ ] Any captions or tooltips broken?
+
+## 3b. Shared-code PRs — broader sweep
+
+If the PR description says it touched anything under `helpers/`,
+`components/`, or `data/shared/`, the change can affect other notebooks
+too. Before approving:
+
+- [ ] Read the list of "affected notebooks" the PR author should have
+      put in the description. (If they didn't list any, ask them to.)
+- [ ] Open the preview URL for **each** affected notebook (the same
+      Cloudflare deploy hosts all of them on the same branch — just
+      navigate to each notebook's URL path).
+- [ ] Spot-check that none of them broke: page loads, plots render,
+      Quick Insights produce sentences, language toggle works.
+
+## 4. Re-run the things that broke before
+
+- [ ] Pick the country / region / scenario combination from your last
+      walkthrough that surfaced bugs (e.g. "Kenya, SSP585, 2061-2080") and
+      step through the affected sections.
+
+## 5. Numbers sanity-check
+
+- [ ] If the PR changes any numerical insight (Quick Insights, captions,
+      tooltips), confirm the numbers look plausible. Compare to the Togo
+      SAT report or another worked example if useful.
+
+## 6. Approve or comment
+
+If everything looks right:
+
+- [ ] Comment on the PR: "Visual review OK. @brayden — ready for technical
+      review."
+- [ ] Mark the PR ready-for-review (un-draft it) using GitHub's UI, or
+      ask Claude Code to do it via the dispatch prompt.
+
+If something looks wrong:
+
+- [ ] Comment on the PR with the specific thing. Be concrete — link to the
+      preview URL with a screenshot if possible.
+- [ ] Either re-dispatch Claude Code to fix it on the same branch, or
+      flag for discussion before re-trying.
+
+## 7. Out-of-scope notes
+
+- [ ] If you spotted something *else* wrong on the page that's outside this
+      PR's scope, **don't fix it here**. Add it to the next ISSUES.md round
+      instead. Note in the PR comment that you saw it so it doesn't get lost.
+
+---
+
+## What not to do in this review
+
+- Don't read the diff. That's Brayden's job.
+- Don't run anything locally. The preview URL is the truth.
+- Don't merge. Even if everything looks perfect — Brayden's technical
+  review still needs to happen.
+- Don't ask Claude Code to "polish" or "make it nicer". Specific
+  asks only.

--- a/playbook/prompts/CLAUDE_CODE_DISPATCH.md
+++ b/playbook/prompts/CLAUDE_CODE_DISPATCH.md
@@ -1,0 +1,126 @@
+# Claude Code — dispatch prompts
+
+Paste-able prompts for the project lead to use **as GitHub issue or PR
+comment bodies**. The repo has a workflow at `.github/workflows/claude.yml`
+that runs Claude Code in GitHub's cloud whenever `@claude` appears in an
+issue or PR comment.
+
+Hard rule: every dispatch must include `@claude` somewhere in the body —
+that's the trigger. The repo's `CLAUDE.md` rules apply automatically;
+don't re-state them.
+
+---
+
+## 1. Standard dispatch — implement one PR group
+
+**Where to paste this:** New GitHub Issue (use the "Dispatch Claude Code"
+template if it's available). Edit the placeholders before submitting.
+
+```text
+@claude
+
+Notebook branch: notebooks/climateRationale
+Handover folder (OneDrive): Climate_data_hub/use_cases/GCF - Preparation Facility/Claude Climate Rational Project
+PR to implement this run: PR-H
+
+Read CLAUDE.md and follow these steps:
+
+1. Read ISSUES.md and DECISIONS.md from the handover folder.
+2. Cut a feature branch off `notebooks/climateRationale` using the naming
+   in CLAUDE.md.
+3. For each issue in PR-H, find the exact `before-string` in the listed
+   file and apply the `proposed-change`. If a `before-string` doesn't
+   match the file exactly, stop and reply with the mismatch — do not
+   improvise.
+4. Commit per logical group with a conventional-commit subject scoped
+   to the notebook.
+5. Push the branch and open a **draft** PR against `notebooks/climateRationale`.
+6. Paste the Cloudflare Pages preview URL into the PR description.
+7. In the PR description, list which CR-NNN issues this closes and
+   anything you flagged or skipped.
+
+Hard rules from CLAUDE.md still apply: don't delete code, don't push
+to main, don't merge.
+```
+
+## 2. Single-issue dispatch
+
+```text
+@claude
+
+Notebook branch: notebooks/climateRationale
+Issue to fix: CR-005 (poverty caption — GSAP 2025 should be GSAP 2023 release)
+Handover folder: Climate_data_hub/use_cases/GCF - Preparation Facility/Claude Climate Rational Project
+
+Cut a branch named `fix/cr-poverty-caption` off the notebook branch,
+apply the exact `proposed-change` for CR-005 from ISSUES.md, commit,
+open a draft PR.
+```
+
+## 3. Iterate on a draft PR — paste as a comment on the PR
+
+```text
+@claude
+
+I reviewed the preview at [preview URL]. Please make the following
+changes on this same branch (don't open a new PR):
+
+- [specific change 1]
+- [specific change 2]
+
+After the changes, mention me in a comment with the updated preview URL.
+```
+
+## 4. Reply to a "before-string didn't match" question
+
+If Claude posts back saying a `before-string` doesn't match, reply with
+the exact content of the file around the relevant area:
+
+```text
+@claude
+
+The file actually reads:
+```
+<paste the relevant 10–20 lines from the current file>
+```
+
+Update ISSUES.md's `before-string` for [CR-XXX] to match this, and
+proceed with the `proposed-change`. Don't change the substantive fix.
+```
+
+## 5. Mark a PR ready for the developer's technical review
+
+```text
+@claude
+
+The preview at [preview URL] looks correct. Please:
+- Mark this PR ready-for-review (un-draft it).
+- Leave a comment summarising what's in it for the developer doing
+  the technical review.
+- Tag @brayden (or whoever is the named reviewer) on the comment.
+```
+
+---
+
+## Style guide for these prompts
+
+- **Always include `@claude`** — without it, the action doesn't fire.
+- **Always name the notebook branch.** Don't assume continuity from a
+  previous comment.
+- **One PR group per dispatch.** Smaller, more reviewable, easier
+  to roll back.
+- **Stay non-technical.** You're describing intent, not implementation.
+  Let `CLAUDE.md` handle the technical details.
+
+## When NOT to use Claude Code in GitHub
+
+Stay in chat-mode Claude (web / desktop / this app) for:
+
+- Drafting a new `ISSUES.md` from raw feedback (Tier 2).
+- Updating `DECISIONS.md` as your thinking changes.
+- Walking through the live preview with another human.
+- Anything where the outcome is markdown / docs / decisions,
+  not a code change.
+
+Switch to GitHub @-claude dispatch only when the outcome is a
+branch + PR + preview URL.


### PR DESCRIPTION
Adds CLAUDE.md (auto-loaded project guide with branch model and hard rules), .github/PULL_REQUEST_TEMPLATE.md (split visual + technical review sections), and the playbook/ directory (four-tier workflow, review checklists, and dispatch prompts).

Updated playbook/WORKFLOW.md to drop the empty `playbook/templates/` reference and point at the `Claude Climate Rational Project/` handover folder as the worked example until proper templates are extracted.