### PR TITLE
fix: resolve notebook text against the site root

### DIFF
--- a/helpers/notebook.js
+++ b/helpers/notebook.js
@@ -1,6 +1,13 @@
 const CONFIG_SCRIPT_ID = "atlas-notebook-config";
 const LOCALES = ["en", "fr"];
 
+// This module is served from <site root>/helpers/, so its own URL gives us the
+// site root. A domain-absolute "/data/..." only works when the site is at the
+// origin root (Cloudflare) and 404s under a prefix (gh-pages /atlas_notebooks/).
+// Quarto's OJS runtime rewrites FileAttachment and "/"-rooted imports for us —
+// a raw fetch gets no such help.
+const SITE_ROOT = new URL("../", import.meta.url);
+
 async function fetchJson(url) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -25,7 +32,7 @@ export async function loadNotebookText(config) {
   const textEntries = await Promise.all(
     LOCALES.map(async (locale) => [
       locale,
-      await fetchJson(`/${config.textDir}/${locale}.json`),
+      await fetchJson(new URL(`${config.textDir}/${locale}.json`, SITE_ROOT)),
     ]),
   );
   return Object.fromEntries(textEntries);


### PR DESCRIPTION
The raw fetch used a domain-absolute path, which only resolves when the site is served at the origin root. Deriving the root from the module URL keeps the localized text loading under the gh-pages prefix too.